### PR TITLE
Update blog.js

### DIFF
--- a/src/templates/blog.js
+++ b/src/templates/blog.js
@@ -44,7 +44,7 @@ export default function Blog(props) {
           <h2>
             Written By: {data.frontmatter.author}
           </h2>
-          <Link to={`blog/${nextSlug}`} className={blogTemplateStyles.footer__next}>
+          <Link to={`/blog/${nextSlug}`} className={blogTemplateStyles.footer__next}>
             <svg xmlns="http://www.w3.org/2000/svg"  version="1.1" x="0px" y="0px" viewBox="0 0 26 26" enableBackground="new 0 0 26 26" >
               <path d="M23.021,12.294l-8.714-8.715l-1.414,1.414l7.007,7.008H2.687v2h17.213l-7.007,7.006l1.414,1.414l8.714-8.713  C23.411,13.317,23.411,12.685,23.021,12.294z"/>
             </svg>


### PR DESCRIPTION
### Problem
The "next blog" link at the bottom of blog posts isn't pointing to the right path.  Example: on the [first blog of the demo site](https://brevifolia-gatsby-forestry.netlify.app/blog/on-the-geneology-of-morals) the link points to [/blog/on-the-geneology-of-morals/blog/ne-te-quaesiveris-extra](https://brevifolia-gatsby-forestry.netlify.app/blog/on-the-geneology-of-morals/blog/ne-te-quaesiveris-extra).  Cause is a missing forward slash which results in the intended path being appended to the current page's path.

I don't understand why, but the missing forward slash doesn't cause a problem in Foresty's preview mode.  It is a problem everywhere else I've tested it.

### Solution
Added a forward slash to the "to=" path of the Link on line 47.  